### PR TITLE
CRS and uncertainty updates

### DIFF
--- a/CBOR-Tag103-Geographic-Coordinates.md
+++ b/CBOR-Tag103-Geographic-Coordinates.md
@@ -12,25 +12,24 @@ This document specifies a tag for Geographic Coordinates.
 
 # Rationale
 
-[Geographic Coordinates](https://en.wikipedia.org/w/index.php?title=Geographic_coordinate_system&oldid=791574160) are used for specifying every location on Earth. Tag 103 can be used to specify Latitude, Longitude, Elevation and Location Uncertainty, following [ISO 6709](https://en.wikipedia.org/wiki/ISO_6709) and [RFC 5870](https://tools.ietf.org/html/rfc5870).
+[Geographic Coordinates](https://en.wikipedia.org/w/index.php?title=Geographic_coordinate_system&oldid=791574160) are used for specifying every location on Earth. Tag 103 can be used to specify Latitude, Longitude, Elevation and Location Uncertainty, or related coordinates based on a defined Coordinate Reference System (CRS), following [ISO 6709](https://en.wikipedia.org/wiki/ISO_6709) and [RFC 5870](https://tools.ietf.org/html/rfc5870).
 
 # Semantics
 
-Tag 103 can be applied to arrays of length 2, 3 and 4.
+Tag 103 can be applied to arrays of length 2 through 6.
 
-Latitude is represented by the first element of the array, in [decimal degrees](https://en.wikipedia.org/wiki/Decimal_degrees), provided in any number format available in CBOR that is precise enough to represent the needed latitude. Positive values indicate latitudes north of the equator, and negative values indicate latitudes south of the equator.
 
-Longitude is represented by the second element of the array, provided in any number format available in CBOR that is precise enough to represent the needed longitude. Positive values indicate longitudes east of the [prime meridian](https://en.wikipedia.org/w/index.php?title=Prime_meridian&oldid=790973897), and negative values indicate longitudes west of the prime meridian.
+Latitude is represented by the first, provided in any number format available in CBOR that is precise enough to represent the needed latitude. Positive values indicate latitudes north of the equator, and negative values indicate latitudes south of the equator unless otherwise specified in the CRS.
 
-Elevation is optionally represented by the third element of the array, provided in any number format available in CBOR that is precise enough to represent the elevation in meters.
+Longitude is represented by the second, provided in any number format available in CBOR that is precise enough to represent the needed longitude. Positive values indicate longitudes east of the prime meridian, and negative values indicate longitudes west of the prime meridian unless otherwise specified in the CRS.
 
-Location Uncertainty is optionally represented by the fourth element of the array, provided in any number format available in CBOR that is precise enough to represent the uncertainty in meters with which the location is known.
+Elevation is optionally represented by the third, provided in any number format available in CBOR that is precise enough to represent the elevation in meters unless otherwise specified in the CRS.
 
-Setting Elevation or Location Uncertainty to `null` (simple value `F6`) should be supported. The effect of setting values to `null` should be the same as omitting them.
+Location Uncertainty is optionally represented by the fourth and/or fifth elements of the array. A single location uncertainty shall represent the uncertainty in meters in both the location and elevation. If two uncertainty elements are present, the first shall be specify the horizontal uncertainty in terms of 90% circular error (CE90) and the second shall specify the vertical uncertainty in terms of 90% linear error (LE90). In all cases, any number format available in CBOR that is precise enough to represent the location uncertainty shall be used.
 
-## Coordinate reference system
+If the final element of the array contains data tagged with CBOR Tag 104-Geographic Coordinate Reference System data that CRS shall be applied to coordinates in this array. If no CRS data is specified, a default CRS shall be assumed. For backward compatibility with an earlier release of this document, the default CRS is EPSG:4326 (WGS84 geographic 3D). An implementation may allow changing of this default CRS by, for example, allowing a naked CBOR tag 104 datum which indicates a change of default CRS. Latitude and logitude are used throughout the rest of this document but they may be substituted for easting and northing or other appropriate terms based on specified CRS.
 
-The coordinate reference system (CRS) in which these values are defined is the World Geodetic System 1984 [WGS-84](http://www.unoosa.org/pdf/icg/2012/template/WGS_84.pdf). The choice of WGS-84 as the default CRS is based on the widespread availability of Global Positioning System (GPS) devices, which use the WGS-84 reference system. This is similar to 'geo' URIs described in [RFC 5870](https://tools.ietf.org/html/rfc5870). Specifying alternative coordinate reference systems is not supported.
+Setting optional elements to `null` (simple value `F6`) shall be supported. The effect of setting values to `null` shall be the same as omitting them.
 
 # Examples
 
@@ -55,6 +54,20 @@ Geographic coordinates of Ghent, Belgium. Altitude and Uncertainty not specified
           F9 4377             # Lon:  3.7324° E        - primitive(17271)
 
     # Diagnostic notation 103([51.0625, 3.732421875])
+
+UTM coordinates of Russian River Brewing, Santa Rosa, California. CRS and uncertainty specified.
+
+    D8 67                     # Geographic Coordinates              - tag(103)
+       86                     #                                     - array(6)
+          FB 412006D46147AE14 # Easting:  525162.19 m               - primitive(4692758320954977812)
+          FB 41503B271A3D70A4 # Northing: 4254876.41 m              - primitive(4706326649732165796)
+          FB 4049800000000000 # Alt:      51.0 m                    - primitive(4632374429215621120)
+          FB 3FF0000000000000 # CE90:     1.0 m                     - primitive(4607182418800017408)
+          FB 4008000000000000 # LE90:     3.0 m                     - primitive(4613937818241073152)
+          D8 68               # CRS                                 - tag(104)
+             19 7FC6          # EPSG:32710 (UTM zone 10S / WGS 84)  - unsigned(32710)
+
+    # Diagnostic notation 103([525162.19, 4254876.41, 51.0, 1.0, 3.0, 104(32710)])
 
 # References
 

--- a/CBOR-Tag104-Geographic-Coordinate-Reference-System.md
+++ b/CBOR-Tag104-Geographic-Coordinate-Reference-System.md
@@ -1,0 +1,59 @@
+# CBOR Geographic Coordinate Reference System
+
+    Tag: 104 (geographic-crs)
+    Data Item: unsigned integer or text string
+    Semantics: Geographic Coordinate Reference System (CRS)
+    Point of contact: Danilo Vidovic <cbor@allthingstalk.com>
+    Description of semantics: https://github.com/allthingstalk/cbor/blob/master/CBOR-Tag104-Geographic-Coordinate-Reference-System.md
+
+# Summary
+
+This document specifies a tag for Geographic Coordinate Reference System specification.
+
+# Rationale
+
+Specifying geographic coordinates for a location on Earth requires the definition of a coordinate reference system. The Earth is approximately an oblate spheroid but the surface is not completely smooth. High precision location on the surface requires better approximations of this uneven surface. In addition, there are multiple origins for these location values. A [Coordinate Reference System (CRS)](https://en.wikipedia.org/wiki/Spatial_reference_system) provides a definition for the coordinate system and a datum used to approximate the surface. This includes any applied projections to 2 dimentional space. Specifying a CRS for geographic coordinates, instead of assuming a fixed CRS, allows for precision location while minimizing the precision of the underlying numeric values.
+
+This tag is designed for use with the Geographic Coordinates CBOR Tag 103 but may be used independently.
+
+# Semantics
+
+Tag 104 can be applied to a primitive positive integer or a text string.
+
+When applied to an integer, the value specifies a European Petroleum Survey Group (EPSG) spatial reference system identifier (SRID). EPSG is one of many SRID providers but is often used as a defacto standard for CRS specification. This application of Tag 104 allows for a compact CRS specification in a manner which can be universally utilized. EPSG definitions are widely available from sources such as [1] and [2] and are often automatically understood by geographic processing tools and libraries.
+
+When a complete CRS definition is needed, either to avoid reliance on EPSG codes or when a particular CRS is not maintained by EPSG, a text string may be utilized with Tag 104. The value should be an Open Geospatial Consortium (OGC) [4] Well-known Text (WKT) [5] CRS definition.
+
+# Examples
+
+CRS for EPSG:4326, the World Geodetic System 1984 horizontal coordinate system used by GPS satellites.
+
+    D8 68      # Geographic Coordinate System - tag(104)
+       19 10E6 # EPSG:4326                    - unsigned(4326)
+
+    # Diagnostic notation: 104(4326)
+
+CRS for WGS 84 3D EGM96 geoid height [3]
+
+    D8 68                                   # Geographic Coordinate System - tag(104)
+       79 0191                              # OGC WKT                      - text(401)
+          47454F4743535B22574753203834202833442045474D39362067656F69642068656967687429222C444154554D5B22576F726C642047656F64657469632053797374656D2031393834222C53504845524F49445B22574753203834222C363337383133372E302C3239382E3235373232333536332C415554484F524954595B2245505347222C2237303330225D5D2C415554484F524954595B2245505347222C2236333236225D5D2C5052494D454D5B22477265656E77696368222C302E302C415554484F524954595B2245505347222C2238393031225D5D2C554E49545B22444D53222C302E30303030303438343831333638313130393533365D2C415849535B2247656F6465746963206C61746974756465222C4E4F5254485D2C415849535B2247656F6465746963206C6F6E676974756465222C454153545D2C415849535B22477261766974792D72656C6174656420686569676874222C55502C415554484F524954595B2245505347222C2235373733225D5D2C415554484F524954595B2245505347222C2234333239225D5D
+
+    # Diagnostic notation: 104("GEOGCS[\"WGS 84 (3D EGM96 geoid height)\",DATUM[\"World Geodetic System 1984\",SPHEROID[\"WGS 84\",6378137.0,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0.0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"DMS\",0.00000484813681109536],AXIS[\"Geodetic latitude\",NORTH],AXIS[\"Geodetic longitude\",EAST],AXIS[\"Gravity-related height\",UP,AUTHORITY[\"EPSG\",\"5773\"]],AUTHORITY[\"EPSG\",\"4329\"]]")
+
+
+# References
+
+[1] [MapTiler EPSG Reference Website](https://epsg.io)
+
+[2] [Spatial Reference Website](http://spatialreference.org)
+
+[3] [SR-ORG:7428](http://spatialreference.org/ref/sr-org/7428/)
+
+[4] [Open Geospatial Consortium](http://www.opengeospatial.org/)
+
+[5] [OGC Well-known Text Representation of Coordinate Reference Systems](https://www.opengeospatial.org/standards/wkt-crs)
+
+# Author
+
+Trevor R.H. Clarke <[trevor@notcows.com](mailto:trevor@notcows.com)>


### PR DESCRIPTION
Add geographic coordinate reference system tag 104.
Add crs (tag 104) support to tag 103.
Add CE90 and LE90 support to tag 103.

Closes #2 and #3 